### PR TITLE
Don't spam blockcypher if we don't need a rate for the action

### DIFF
--- a/cnd/src/http_api/swaps.rs
+++ b/cnd/src/http_api/swaps.rs
@@ -147,7 +147,6 @@ async fn handle_action(
         .get(&id)
         .cloned()
         .ok_or(ActionNotFound)?;
-    let btc_per_vbyte = bitcoin_fees.get_per_vbyte_rate().await?;
 
-    ActionResponseBody::from_action(action, btc_per_vbyte)
+    ActionResponseBody::from_action(action, bitcoin_fees).await
 }


### PR DESCRIPTION
By passing down the BitcoinFees struct, we can defer the API call
up until we actual need the rate. This makes all action endpoints
cheap to call again.