### PR TITLE
Only trigger mergify if none of the build checks fail

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,7 +3,7 @@ pull_request_rules:
     conditions:
       - "author=dependabot[bot]"
       - "status-success=static_analysis"
-      - "status-success~=^build"
+      - "-status-failure~=^build"
       - label!=no-mergify
     actions:
       comment:
@@ -13,7 +13,7 @@ pull_request_rules:
       - "#approved-reviews-by>=2"
       - "#changes-requested-reviews-by=0"
       - "status-success=static_analysis"
-      - "status-success~=^build"
+      - "-status-failure~=^build"
       - -conflict
       - label!=work-in-progress
       - label!=blocked


### PR DESCRIPTION
Recently [1], we've expanded our CI build checks from 3 to 4. Maintaining
this list of checks became cumbersome and as such, we tried to
optimize this [2].

Unfortunately, the solution in [2] didn't work because it triggers
as soon as _any_ of the "build" checks succeed.

This patch uses double-negation to make sure we only trigger mergify
if none of the "build" checks fail. Consequently, all of them need
to succeed for mergify to consider this rule matching.

[1]: https://github.com/comit-network/comit-rs/pull/3364
[2]: https://github.com/comit-network/comit-rs/pull/3364